### PR TITLE
Allow app version to be specified in options

### DIFF
--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -72,7 +72,9 @@
                                  class-name))
                :severity (or (:severity options) "error")
                :user (:user options)
-               :app {:version (string/trim (:out (sh "git" "rev-parse" "HEAD")))
+               :app {:version (if (contains? options :version)
+                                (:version options)
+                                (string/trim (:out (sh "git" "rev-parse" "HEAD"))))
                      :releaseStage (or (:environment options) "production")}
                :device {:hostname (.. java.net.InetAddress getLocalHost getHostName)}
                :metaData (walk/postwalk stringify (merge base-meta (:meta options)))}]}))


### PR DESCRIPTION
Passing in a version key prevents shell-ing out to git for deployments
that do not have git access. The value of the version key can be nil (as
allowed by the bugsnag API).