### PR TITLE
report git revision only when git is available

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-bugsnag "0.2.8"
+(defproject clj-bugsnag "0.2.9"
   :description "Fully fledged Bugsnag client. Supports ex-data and ring middleware."
   :url "https://github.com/wunderlist/clj-bugsnag"
   :license {:name "Eclipse Public License"

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -9,6 +9,11 @@
             [clojure.string :as string]
             [clojure.walk :as walk]))
 
+(def git-rev
+  (delay (try
+    (string/trim (:out (sh "git" "rev-parse" "HEAD")))
+    (catch Exception ex "git revision not available"))))
+
 (defn- find-source-snippet
   [around, function-name]
   (try
@@ -74,7 +79,7 @@
                :user (:user options)
                :app {:version (if (contains? options :version)
                                 (:version options)
-                                (string/trim (:out (sh "git" "rev-parse" "HEAD"))))
+                                git-rev)
                      :releaseStage (or (:environment options) "production")}
                :device {:hostname (.. java.net.InetAddress getLocalHost getHostName)}
                :metaData (walk/postwalk stringify (merge base-meta (:meta options)))}]}))


### PR DESCRIPTION
`git` isn't available inside some docker containers.. don't rely on it