### PR TITLE
Add explicit Cheshire dependency to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
     [org.clojure/clojure "1.6.0"]
     [clj-stacktrace "0.2.8"]
     [clj-http "2.0.0"]
+    [cheshire "5.5.0"]
     [environ "1.0.2"]
     [org.clojure/data.json "0.2.6"]]
 


### PR DESCRIPTION
With clj-http 2.0.0, if using :as :json, the Cheshire dependency must be
required in project.clj otherwise the network request fails with an
exception that the Cheshire dependency isn't loaded.

See [clj-http's readme on optional dependencies](https://github.com/dakrone/clj-http#optional-dependencies)

Another option here is adding a note in the README that if using clj-bugsnag, one would need to include cheshire in their project.clj but it seems preferable that this library would work out of the box?