### PR TITLE
Add an option for notify-environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Maven dependency information:
   {:api-key "Project API key"
    ;; Defaults to "production"
    :environment "production"
+   ;; A set of environments to notify bugsnag in
+   ;; Defaults to notifying in all environments
+   :notify-environments #{"production" "staging"}
    ;; Project namespace prefix, used to hide irrelevant stack trace elements
    :project-ns "your-project-ns-prefix"
    ;; A optional version for your app, this is displayed in bugsnag.

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -46,3 +46,9 @@
   (-> (core/exception->json (ex-info "BOOM" {}) {}) :apiKey) => ..bugsnag-key..
   (provided
     (env :bugsnag-key) => ..bugsnag-key..))
+
+(fact "notifies bugsnag with the appropriate notify-environments"
+  (core/should-notify? nil) => truthy
+  (core/should-notify? {:notify-environments nil}) => truthy
+  (core/should-notify? {:notify-environments #{"development"} :environment "development"}) => truthy
+  (core/should-notify? {:notify-environments #{"production"} :environment "development"}) => falsey)


### PR DESCRIPTION
Allows notifying bugsnag in only certain environments. Helpful for
avoiding exception reporting in development environment for example.
Parallels the semantics in other bugsnag libraries, such as the JS
library that has a "notifyReleaseStages"

Does this seem like a reasonable feature for the Clojure library to implement? It parallels the functionality of the JS and Java bugsnag libraries. At the moment we can wrap up the notifier function in a should-notify in our own projects, but across a lot of projects it becomes a little tedious.
