### PR TITLE
Nested exception support

### DIFF
--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -54,12 +54,21 @@
     thing
     (str thing)))
 
+(defn- unroll [ex options]
+  (let [class-name (.getName (:class ex))
+        project-ns (get options :project-ns "\000")
+        stacktrace (transform-stacktrace (:trace-elems ex) project-ns)
+        current {:errorClass class-name
+                 :message (:message ex)
+                 :stacktrace stacktrace}]
+    (if-let [next (:cause ex)]
+      (conj (unroll next options) current)
+      [current])))
+
 (defn exception->json
   [exception options]
   (let [ex (parse-exception exception)
         class-name (.getName (:class ex))
-        project-ns (get options :project-ns "\000")
-        stacktrace (transform-stacktrace (:trace-elems ex) project-ns)
         base-meta (if-let [d (ex-data exception)]
                     {"ex–data" d}
                     {})]
@@ -68,9 +77,7 @@
                 :version "0.2.2"
                 :url "https://github.com/wunderlist/clj-bugsnag"}
      :events [{:payloadVersion "2"
-               :exceptions [{:errorClass class-name
-                             :message (:message ex)
-                             :stacktrace stacktrace}]
+               :exceptions (unroll ex options)
                :context (:context options)
                :groupingHash (or (:group options)
                                (if (isa? (type exception) clojure.lang.ExceptionInfo)

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -54,21 +54,21 @@
     thing
     (str thing)))
 
-(defn- unroll [ex options]
+(defn- unroll [ex project-ns]
   (let [class-name (.getName (:class ex))
-        project-ns (get options :project-ns "\000")
         stacktrace (transform-stacktrace (:trace-elems ex) project-ns)
         current {:errorClass class-name
                  :message (:message ex)
                  :stacktrace stacktrace}]
     (if-let [next (:cause ex)]
-      (conj (unroll next options) current)
+      (conj (unroll next project-ns) current)
       [current])))
 
 (defn exception->json
   [exception options]
   (let [ex (parse-exception exception)
         class-name (.getName (:class ex))
+        project-ns (get options :project-ns "\000")
         base-meta (if-let [d (ex-data exception)]
                     {"ex–data" d}
                     {})]
@@ -77,7 +77,7 @@
                 :version "0.2.2"
                 :url "https://github.com/wunderlist/clj-bugsnag"}
      :events [{:payloadVersion "2"
-               :exceptions (unroll ex options)
+               :exceptions (unroll ex project-ns)
                :context (:context options)
                :groupingHash (or (:group options)
                                (if (isa? (type exception) clojure.lang.ExceptionInfo)

--- a/src/clj_bugsnag/core.clj
+++ b/src/clj_bugsnag/core.clj
@@ -55,14 +55,17 @@
     (str thing)))
 
 (defn- unroll [ex project-ns]
-  (let [class-name (.getName (:class ex))
-        stacktrace (transform-stacktrace (:trace-elems ex) project-ns)
-        current {:errorClass class-name
-                 :message (:message ex)
-                 :stacktrace stacktrace}]
-    (if-let [next (:cause ex)]
-      (conj (unroll next project-ns) current)
-      [current])))
+  (loop [collected []
+         current ex]
+    (let [class-name (.getName (:class current))
+          stacktrace (transform-stacktrace (:trace-elems current) project-ns)
+          new-item {:errorClass class-name
+                    :message (:message current)
+                    :stacktrace stacktrace}
+          collected (cons new-item collected)]
+      (if-let [next (:cause current)]
+        (recur collected next)
+        collected))))
 
 (defn exception->json
   [exception options]

--- a/test/clj_bugsnag/core_test.clj
+++ b/test/clj_bugsnag/core_test.clj
@@ -46,3 +46,10 @@
   (-> (core/exception->json (ex-info "BOOM" {}) {}) :apiKey) => ..bugsnag-key..
   (provided
     (env :bugsnag-key) => ..bugsnag-key..))
+
+(fact "includes nested exceptions"
+  (let [e1 (Exception. "Inner")
+        e2 (Exception. "Middle" e1)
+        e3 (Exception. "Outer"  e2)]
+    (->> (core/exception->json e3 {}) :events first :exceptions (map :message))
+  => ["Inner" "Middle" "Outer"]))


### PR DESCRIPTION
An excerpt from the Bugsnag API docs:
~~~~
        // An array of exceptions that occurred during this event. Most of the
        // time there will only be one exception, but some languages support
        // "nested" or "caused by" exceptions. In this case, exceptions should
        // be unwrapped and added to the array one at a time. The first
        // exception raised should be first in this array.
        exceptions: [{
...
~~~~